### PR TITLE
introduce RelationBinding::destination_columns.

### DIFF
--- a/analyzer/src/impl/Engine.h
+++ b/analyzer/src/impl/Engine.h
@@ -234,6 +234,8 @@ private:
             model::Node*, binding::RelationBinding::Profile&,
             common::schema::TableInfo const&, common::schema::IndexInfo const&);
 
+    std::vector<std::shared_ptr<binding::VariableBinding>> create_column_variables(common::schema::TableInfo const&);
+
     std::vector<binding::RelationBinding::JoinColumn> compute_join_columns(
             model::expression::relation::JoinExpression const* node,
             std::vector<std::shared_ptr<binding::VariableBinding>> const& left_variables,


### PR DESCRIPTION
This PR introduces `RelationBinding::destination_columns` for DML statement results.
Note that, `RelationBinding::output` profile is no longer available for DML statements.