### PR TITLE
introduce `{Scan,Join}Strategy` into `RelationBinding`.

### DIFF
--- a/analyzer/include/shakujo/analyzer/binding/BindingSerializer.h
+++ b/analyzer/include/shakujo/analyzer/binding/BindingSerializer.h
@@ -116,13 +116,6 @@ public:
      * @param printer the destination printer
      * @param value the target value
      */
-    virtual void serialize(common::util::DataSerializer& printer, RelationBinding::JoinColumn const* value);  // NOLINT
-
-    /**
-     * @brief serializes the value into given printer.
-     * @param printer the destination printer
-     * @param value the target value
-     */
     virtual void serialize(common::util::DataSerializer& printer, common::schema::TableInfo const* value);  // NOLINT
 
     /**
@@ -131,6 +124,41 @@ public:
      * @param value the target value
      */
     virtual void serialize(common::util::DataSerializer& printer, common::schema::IndexInfo const* value);  // NOLINT
+
+    /**
+     * @brief serializes the value into given printer.
+     * @param printer the destination printer
+     * @param value the target value
+     */
+    virtual void serialize(common::util::DataSerializer& printer, ScanStrategy const* value);  // NOLINT
+
+    /**
+     * @brief serializes the value into given printer.
+     * @param printer the destination printer
+     * @param value the target value
+     */
+    virtual void serialize(common::util::DataSerializer& printer, ScanStrategy::Kind value);  // NOLINT
+
+    /**
+     * @brief serializes the value into given printer.
+     * @param printer the destination printer
+     * @param value the target value
+     */
+    virtual void serialize(common::util::DataSerializer& printer, JoinStrategy const* value);  // NOLINT
+
+    /**
+     * @brief serializes the value into given printer.
+     * @param printer the destination printer
+     * @param value the target value
+     */
+    virtual void serialize(common::util::DataSerializer& printer, JoinStrategy::Kind value);  // NOLINT
+
+    /**
+     * @brief serializes the value into given printer.
+     * @param printer the destination printer
+     * @param value the target value
+     */
+    virtual void serialize(common::util::DataSerializer& printer, JoinStrategy::Column const* value);  // NOLINT
 };
 
 }  // namespace shakujo::analyzer::binding

--- a/analyzer/include/shakujo/analyzer/binding/JoinStrategy.h
+++ b/analyzer/include/shakujo/analyzer/binding/JoinStrategy.h
@@ -1,0 +1,356 @@
+/*
+ * Copyright 2018 shakujo project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SHAKUJO_ANALYZER_JOIN_STRATEGY_H_
+#define SHAKUJO_ANALYZER_JOIN_STRATEGY_H_
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "VariableBinding.h"
+
+namespace shakujo::analyzer::binding {
+
+/**
+ * @brief represents how perform join operation.
+ */
+class JoinStrategy {
+public:
+    /**
+     * @brief represents scan kind.
+     */
+    enum class Kind {
+        /**
+         * @brief union join.
+         */
+        UNION,
+
+        /**
+         * @brief nested loop join.
+         */
+        NESTED_LOOP,
+    };
+
+    /**
+     * @brief join operation detail of each resulting column.
+     */
+    class Column {
+    public:
+        /**
+         * @brief constructs a new object.
+         * @param qualifiers the output variable qualifiers - FIXME: variable binding with aliases instead
+         * @param output the output column binding
+         * @param left_source the source column binding from the left operand
+         * @param nullify_left_source whether or not the value from the left operand must be nullified
+         * @param right_source the source column binding from the right operand
+         * @param nullify_right_source whether or not the value from the right operand must be nullified
+         */
+        Column(
+                std::vector<common::core::Name> qualifiers,
+                std::shared_ptr<VariableBinding> output,
+                std::shared_ptr<VariableBinding> left_source, bool nullify_left_source,
+                std::shared_ptr<VariableBinding> right_source, bool nullify_right_source)
+            : qualifiers_(std::move(qualifiers)), output_(std::move(output))
+            , left_source_(std::move(left_source)), nullify_left_source_(nullify_left_source)
+            , right_source_(std::move(right_source)), nullify_right_source_(nullify_right_source)
+        {}
+
+        /**
+         * @brief returns the available output column qualifiers.
+         * @return output column qualifiers
+         */
+        std::vector<common::core::Name> const& qualifiers() const {
+            return qualifiers_;
+        }
+
+        /**
+         * @brief returns the output column binding.
+         * @return the output column binding
+         */
+        std::shared_ptr<VariableBinding> output() const {
+            return output_;
+        }
+
+        /**
+         * @brief returns the source column binding from the left operand.
+         * @return the source column binding
+         * @return empty if the target output does not refer column from the left operand
+         */
+        std::shared_ptr<VariableBinding> left_source() const {
+            return left_source_;
+        }
+
+        /**
+         * @brief returns the source column binding from the right operand.
+         * @return the source column binding
+         * @return empty if the target output does not refer column from the right operand
+         */
+        std::shared_ptr<VariableBinding> right_source() const {
+            return right_source_;
+        }
+
+        /**
+         * @brief returns whether or not the value from left operand must be nullified before compare or output.
+         * @return true if the output column value must be nullified
+         * @return false otherwise, or the target output does not refer value from the left operand
+         */
+        bool nullify_left_source() const {
+            return nullify_left_source_;
+        }
+
+        /**
+         * @brief returns whether or not the value from right operand must be nullified before compare or output.
+         * @return true if the output column value must be nullified
+         * @return false otherwise, or the target output does not refer value from the right operand
+         */
+        bool nullify_right_source() const {
+            return nullify_right_source_;
+        }
+
+    private:
+        std::vector<common::core::Name> qualifiers_;
+        std::shared_ptr<VariableBinding> output_;
+        std::shared_ptr<VariableBinding> left_source_;
+        bool nullify_left_source_;
+        std::shared_ptr<VariableBinding> right_source_;
+        bool nullify_right_source_;
+    };
+
+    /**
+     * @brief constructs a new object.
+     */
+    JoinStrategy() noexcept : JoinStrategy(Kind::NESTED_LOOP, false, false, false, false, false) {}
+
+    /**
+     * @brief constructs a new object.
+     * @param kind the join kind
+     * @param natural is natural join
+     * @param left_outer is left/full outer join
+     * @param right_outer is right/full outer join
+     * @param left_semi is left semi join
+     * @param right_semi is right semi join
+     * @param columns the join columns
+     */
+    JoinStrategy(
+            Kind kind,
+            bool natural,
+            bool left_outer,
+            bool right_outer,
+            bool left_semi,
+            bool right_semi,
+            std::vector<Column> columns = {})
+        : kind_(kind)
+        , natural_(natural)
+        , left_outer_(left_outer)
+        , right_outer_(right_outer)
+        , left_semi_(left_semi)
+        , right_semi_(right_semi)
+        , columns_(std::move(columns))
+    {}
+
+    /**
+     * @brief returns the kind of this strategy.
+     * @return the strategy kind
+     */
+    Kind kind() const {
+        return kind_;
+    }
+
+    /**
+     * @brief sets the kind of this strategy.
+     * @param kind the strategy kind
+     * @return this
+     */
+    JoinStrategy& kind(Kind kind) {
+        kind_ = kind;
+        return *this;
+    }
+
+    /**
+     * @brief returns whether or not this operation is natural join.
+     * @return true if this is natural join
+     * @return false otherwise
+     */
+    bool natural() const {
+        return natural_;
+    }
+
+    /**
+     * @brief sets wether or not this operation is natural join.
+     * @param on true to mark as natural join
+     * @return this
+     */
+    JoinStrategy& natural(bool on) {
+        natural_ = on;
+        return *this;
+    }
+
+    /**
+     * @brief returns whether or not left input always stay in the result even if opposite does not exist.
+     * @return true is left or full outer join
+     * @return false otherwise
+     * @return undefined if this is union join
+     */
+    bool left_outer() const {
+        return left_outer_;
+    }
+
+    /**
+     * @brief sets whether or not left input always stay in the result even if opposite does not exist.
+     * @param on true for left or full outer join
+     * @return this
+     */
+    JoinStrategy& left_outer(bool on) {
+        left_outer_ = on;
+        return *this;
+    }
+
+    /**
+     * @brief returns whether or not right input always stay in the result even if opposite does not exist.
+     * @return true is right or full outer join
+     * @return false otherwise
+     * @return undefined if this is union join
+     */
+    bool right_outer() const {
+        return right_outer_;
+    }
+
+    /**
+     * @brief sets whether or not right input always stay in the result even if opposite right does not exist.
+     * @param on true for right or full outer join
+     * @return this
+     */
+    JoinStrategy& right_outer(bool on) {
+        right_outer_ = on;
+        return *this;
+    }
+
+    /**
+     * @brief returns whether or not this operation is left semi join.
+     * @return true if this is left semi join
+     * @return false otherwise
+     */
+    bool left_semi() const {
+        return left_semi_;
+    }
+
+    /**
+     * @brief sets wether or not this operation is natural join.
+     * @param on true to mark as natural join
+     * @return this
+     */
+    JoinStrategy& left_semi(bool on) {
+        left_semi_ = on;
+        return *this;
+    }
+
+    /**
+     * @brief returns whether or not this operation is right semi join.
+     * @return true if this is right semi join
+     * @return false otherwise
+     */
+    bool right_semi() const {
+        return right_semi_;
+    }
+
+    /**
+     * @brief sets wether or not this operation is natural join.
+     * @param on true to mark as natural join
+     * @return this
+     */
+    JoinStrategy& right_semi(bool on) {
+        right_semi_ = on;
+        return *this;
+    }
+
+    /**
+     * @brief returns the join operation of individual columns.
+     * @return the join operations
+     * @return empty if the corresponded operation is not a valid join
+     */
+    std::vector<Column>& columns() {
+        return columns_;
+    }
+
+    /**
+     * @brief returns the join operation of individual columns.
+     * This is only available for JoinExpressions.
+     * @return the join operations
+     * @return empty if the corresponded operation is not a valid join
+     */
+    std::vector<Column> const& columns() const {
+        return columns_;
+    }
+
+    /**
+     * @brief returns whether or not this object is valid.
+     * @return true if this is valid
+     * @return false otherwise
+     */
+    bool is_valid() const {
+        return !columns_.empty();
+    }
+
+    /**
+     * @brief returns whether or not this object is valid.
+     * @return true if this is valid
+     * @return false otherwise
+     */
+    explicit operator bool() const {
+        return is_valid();
+    }
+
+private:
+    Kind kind_;
+    bool natural_;
+    bool left_outer_;
+    bool right_outer_;
+    bool left_semi_;
+    bool right_semi_;
+    std::vector<Column> columns_;
+};
+
+
+/**
+ * @brief returns string representation of the given value.
+ * @param value the target enum constant
+ * @return string representation
+ */
+inline constexpr std::string_view to_string_view(JoinStrategy::Kind value) {
+    using Kind = JoinStrategy::Kind;
+    switch (value) {
+        case Kind::UNION: return "UNION";
+        case Kind::NESTED_LOOP: return "NESTED_LOOP";
+    }
+    return "(unknown)";
+}
+
+/**
+ * @brief append textual representation of Diagnostic::Code.
+ * @param out the target output stream
+ * @param value the target value
+ * @return the output stream
+ */
+inline std::ostream& operator<<(std::ostream& out, JoinStrategy::Kind value) {
+    return out << to_string_view(value);
+}
+
+}  // namespace shakujo::analyzer::binding
+
+#endif  //SHAKUJO_ANALYZER_JOIN_STRATEGY_H_

--- a/analyzer/include/shakujo/analyzer/binding/ScanStrategy.h
+++ b/analyzer/include/shakujo/analyzer/binding/ScanStrategy.h
@@ -1,0 +1,259 @@
+/*
+ * Copyright 2018 shakujo project.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef SHAKUJO_ANALYZER_SCAN_STRATEGY_H_
+#define SHAKUJO_ANALYZER_SCAN_STRATEGY_H_
+
+#include <iostream>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include <cstdlib>
+
+#include "VariableBinding.h"
+
+#include "shakujo/common/core/Value.h"
+#include "shakujo/common/schema/TableInfo.h"
+#include "shakujo/common/schema/IndexInfo.h"
+#include "shakujo/common/util/utility.h"
+
+namespace shakujo::analyzer::binding {
+
+/**
+ * @brief represents how perform scan operation.
+ */
+class ScanStrategy {
+public:
+    /**
+     * @brief represents scan kind.
+     */
+    enum class Kind {
+        /**
+         * @brief range scan.
+         */
+        RANGE,
+
+        /**
+         * @brief prefix scan.
+         */
+        PREFIX,
+
+        /**
+         * @brief full scan.
+         */
+        FULL,
+    };
+
+    /**
+     * @brief constructs a new object.
+     */
+    ScanStrategy() noexcept = default;
+
+    /**
+     * @brief constructs a new object.
+     * @param table the target table
+     * @param kind the strategy kind
+     */
+    ScanStrategy(common::schema::TableInfo const& table, Kind kind = Kind::FULL) noexcept  // NOLINT
+        : kind_(kind)
+        , table_(&table)
+    {}
+
+    /**
+     * @brief returns the kind of this strategy.
+     * If the kind is FULL, executor must evaluate the condition in ScanExpression manually.
+     * @return the strategy kind
+     */
+    Kind kind() const {
+        return kind_;
+    }
+
+    /**
+     * @brief sets the kind of this strategy.
+     * @param kind the strategy kind
+     * @return this
+     */
+    ScanStrategy& kind(Kind kind) {
+        kind_ = kind;
+        return *this;
+    }
+
+    /**
+     * @brief returns information about the scan target table.
+     * @return the scan target table
+     */
+    common::schema::TableInfo const& table() const {
+        if (common::util::is_valid(table_)) {
+            return *table_;
+        }
+        static common::schema::TableInfo const INVALID {};
+        return INVALID;
+    }
+
+    /**
+     * @brief returns information about the scan target index.
+     * @return the scan target index
+     * @return invalid information if this strategy just represents table full scan
+     */
+    common::schema::IndexInfo const& index() const {
+        if (common::util::is_valid(index_)) {
+            return *index_;
+        }
+        static common::schema::IndexInfo const INVALID {};
+        return INVALID;
+    }
+
+    /**
+     * @brief returns the bindings of target key columns.
+     * The resulting variables just correspond to key of the target index.
+     * @return bindings of the target index columns
+     * @return empty if this strategy just represents table full scan
+     */
+    std::vector<std::shared_ptr<VariableBinding>> const& key_columns() const {
+        return key_columns_;
+    }
+
+    /**
+     * @brief returns the lower limit of range scan.
+     * This may return shorter vector than the key_columns().
+     * @return the lower limit
+     * @return empty if this strategy is not a kind of range scan, or range scan with no lower limit
+     */
+    std::vector<std::unique_ptr<common::core::Value>> const& lower_limit() const {
+        return lower_limit_;
+    }
+
+    /**
+     * @brief returns whether or not range scan includes entry on the lower limit.
+     * @return true if the lower limit is inclusive
+     * @return false otherwise
+     */
+    bool lower_inclusive() const {
+        return lower_inclusive_;
+    }
+
+    /**
+     * @brief returns the upper limit of range scan.
+     * This may return shorter vector than the key_columns().
+     * @return the upper limit
+     * @return empty if this strategy is not a kind of range scan, or range scan with no upper limit
+     */
+    std::vector<std::unique_ptr<common::core::Value>> const& upper_limit() const {
+        return upper_limit_;
+    }
+
+    /**
+     * @brief returns whether or not range scan includes entry on the upper limit.
+     * @return true if the upper limit is inclusive
+     * @return false otherwise
+     */
+    bool upper_inclusive() const {
+        return upper_inclusive_;
+    }
+
+    /**
+     * @brief returns the key prefix of prefix scan.
+     * If this returned as many values as the index key columns, this strategy intends to obtain single entry.
+     * @return the key or key prefix
+     * @return empty if this strategy is not a kind of prefix scan
+     */
+    std::vector<std::unique_ptr<common::core::Value>> const& prefix() const {
+        return prefix_;
+    }
+
+    /**
+     * @brief returns whether or not this object is valid.
+     * @return true if this is valid
+     * @return false otherwise
+     */
+    bool is_valid() const {
+        if (!common::util::is_valid(table_)) {
+            return false;
+        }
+        if (kind_ == Kind::FULL) {
+            if (common::util::is_valid(index_)) {
+                if (index_->columns().size() != key_columns_.size()) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        if (!common::util::is_valid(index_)) {
+            return false;
+        }
+        if (index_->columns().size() != key_columns_.size()) {
+            return false;
+        }
+        if (kind_ == Kind::RANGE) {
+            return !lower_limit_.empty() || !upper_limit_.empty();
+        }
+        if (kind_ == Kind::PREFIX) {
+            return !prefix_.empty();
+        }
+        std::abort();
+    }
+
+    /**
+     * @brief returns whether or not this object is valid.
+     * @return true if this is valid
+     * @return false otherwise
+     */
+    explicit operator bool() const {
+        return is_valid();
+    }
+
+private:
+    Kind kind_ { Kind::FULL };
+    common::schema::TableInfo const* table_ {};
+    common::schema::IndexInfo const* index_ {};
+    std::vector<std::shared_ptr<VariableBinding>> key_columns_ {};
+    std::vector<std::unique_ptr<common::core::Value>> lower_limit_ {};
+    bool lower_inclusive_ {};
+    std::vector<std::unique_ptr<common::core::Value>> upper_limit_ {};
+    bool upper_inclusive_ {};
+    std::vector<std::unique_ptr<common::core::Value>> prefix_ {};
+};
+
+/**
+ * @brief returns string representation of the given value.
+ * @param value the target enum constant
+ * @return string representation
+ */
+inline constexpr std::string_view to_string_view(ScanStrategy::Kind value) {
+    using Kind = ScanStrategy::Kind;
+    switch (value) {
+        case Kind::RANGE: return "RANGE";
+        case Kind::PREFIX: return "PREFIX";
+        case Kind::FULL: return "FULL";
+    }
+    return "(unknown)";
+}
+
+/**
+ * @brief append textual representation of Diagnostic::Code.
+ * @param out the target output stream
+ * @param value the target value
+ * @return the output stream
+ */
+inline std::ostream& operator<<(std::ostream& out, ScanStrategy::Kind value) {
+    return out << to_string_view(value);
+}
+
+}  // namespace shakujo::analyzer::binding
+
+#endif  //SHAKUJO_ANALYZER_SCAN_STRATEGY_H_

--- a/analyzer/src/SyntaxValidator.cpp
+++ b/analyzer/src/SyntaxValidator.cpp
@@ -425,9 +425,6 @@ protected:
         }
         switch (node->operator_kind()) {
             case Kind::INNER:
-            case Kind::LEFT_OUTER:
-            case Kind::RIGHT_OUTER:
-            case Kind::FULL_OUTER:
                 // don't care whether or not join specification exists
                 break;
 
@@ -443,6 +440,9 @@ protected:
                 }
                 break;
 
+            case Kind::LEFT_OUTER:
+            case Kind::RIGHT_OUTER:
+            case Kind::FULL_OUTER:
             case Kind::LEFT_SEMI:
             case Kind::RIGHT_SEMI:
                 if (!is_defined(node->condition())) {

--- a/analyzer/src/binding/BindingContext.cpp
+++ b/analyzer/src/binding/BindingContext.cpp
@@ -18,7 +18,12 @@
 #include <sstream>
 #include <stdexcept>
 
+#include "shakujo/common/util/utility.h"
+
 namespace shakujo::analyzer::binding {
+
+using common::util::is_defined;
+using common::util::to_string;
 
 namespace {
     template<typename B, typename K = typename B::key_type>
@@ -58,15 +63,13 @@ public:
     typename std::shared_ptr<typename T::binding_type> extract(
             typename T::key_type const* key,
             std::string_view name = {}) const {
-        if (!key->template has_entity<T>()) {
+        if (!is_defined(key) || !key->template has_entity<T>()) {
             if (name.empty()) return {};
             std::ostringstream ss;
-            if (key->template has_entity<typename T::entity_type>()) {
-                ss << name << " is not yet initialized";
-            } else {
-                ss << name << " is incompatible for this context kind";
+            if (!is_defined(key) || key->template has_entity<typename T::entity_type>()) {
+                throw std::domain_error(to_string(name, " is not yet initialized"));
             }
-            throw std::domain_error(ss.str());
+            throw std::domain_error(to_string(name, " is incompatible for this context kind"));
         }
         auto entity = key->template entity<T>();
         if (entity->identity_.get() != identity_.get()) {

--- a/analyzer/src/binding/BindingSerializer.cpp
+++ b/analyzer/src/binding/BindingSerializer.cpp
@@ -251,15 +251,14 @@ void BindingSerializer::serialize(common::util::DataSerializer& printer, Relatio
         printer.exit_property("destination_columns");
     }
     {
-        printer.enter_property("join_columns");
-        auto& list = value->join_columns();
-        auto size = list.size();
-        printer.enter_array(size);
-        for (auto& element : list) {
-            serialize(printer, &element);
-        }
-        printer.exit_array(size);
-        printer.exit_property("join_columns");
+        printer.enter_property("scan_strategy");
+        serialize(printer, &value->scan_strategy());
+        printer.exit_property("scan_strategy");
+    }
+    {
+        printer.enter_property("join_strategy");
+        serialize(printer, &value->join_strategy());
+        printer.exit_property("join_strategy");
     }
     printer.exit_object("RelationBinding");
 }
@@ -294,11 +293,6 @@ void BindingSerializer::serialize(common::util::DataSerializer &printer, Relatio
             printer.enter_property("source_table");
             serialize(printer, &value->source_table());
             printer.exit_property("source_table");
-        }
-        {
-            printer.enter_property("source_index");
-            serialize(printer, &value->source_index());
-            printer.exit_property("source_index");
         }
         {
             printer.enter_property("order");
@@ -346,15 +340,216 @@ void BindingSerializer::serialize(common::util::DataSerializer& printer, Relatio
     }
 }
 
-void BindingSerializer::serialize(common::util::DataSerializer& printer, RelationBinding::JoinColumn const* value) {
+void BindingSerializer::serialize(common::util::DataSerializer& printer, common::schema::TableInfo const* value) {
+    if (!is_valid(value)) {
+        printer.value(nullptr);
+        return;
+    }
+    printer.enter_object("TableInfo");
+    {
+        printer.enter_property("name");
+        printer.value(value->name());
+        printer.exit_property("name");
+    }
+    printer.exit_object("TableInfo");
+}
+
+void BindingSerializer::serialize(common::util::DataSerializer& printer, common::schema::IndexInfo const* value) {
+    if (!is_valid(value)) {
+        printer.value(nullptr);
+        return;
+    }
+    printer.enter_object("IndexInfo");
+    {
+        printer.enter_property("is_primary");
+        printer.value(value->is_primary());
+        printer.exit_property("is_primary");
+    }
+    {
+        printer.enter_property("name");
+        printer.value(value->name());
+        printer.exit_property("name");
+    }
+    printer.exit_object("IndexInfo");
+}
+
+void BindingSerializer::serialize(common::util::DataSerializer& printer, ScanStrategy const* value) {
+    if (value == nullptr) {
+        printer.value(nullptr);
+        return;
+    }
+    printer.enter_object("ScanStrategy");
+    {
+        printer.enter_property("kind");
+        serialize(printer, value->kind());
+        printer.exit_property("kind");
+    }
+    {
+        printer.enter_property("table");
+        serialize(printer, &value->table());
+        printer.exit_property("table");
+    }
+    {
+        printer.enter_property("index");
+        serialize(printer, &value->index());
+        printer.exit_property("index");
+    }
+    {
+        printer.enter_property("key_columns");
+        auto& list = value->key_columns();
+        auto size = list.size();
+        printer.enter_array(size);
+        for (auto& element : list) {
+            serialize(printer, element.get());
+        }
+        printer.exit_array(size);
+        printer.exit_property("key_columns");
+    }
+    {
+        printer.enter_property("lower_limit");
+        auto& list = value->lower_limit();
+        auto size = list.size();
+        printer.enter_array(size);
+        for (auto& element : list) {
+            serialize(printer, element.get());
+        }
+        printer.exit_array(size);
+        printer.exit_property("lower_limit");
+    }
+    {
+        printer.enter_property("lower_inclusive");
+        printer.value(value->lower_inclusive());
+        printer.exit_property("lower_inclusive");
+    }
+    {
+        printer.enter_property("upper_limit");
+        auto& list = value->upper_limit();
+        auto size = list.size();
+        printer.enter_array(size);
+        for (auto& element : list) {
+            serialize(printer, element.get());
+        }
+        printer.exit_array(size);
+        printer.exit_property("upper_limit");
+    }
+    {
+        printer.enter_property("upper_inclusive");
+        printer.value(value->upper_inclusive());
+        printer.exit_property("upper_inclusive");
+    }
+    {
+        printer.enter_property("prefix");
+        auto& list = value->prefix();
+        auto size = list.size();
+        printer.enter_array(size);
+        for (auto& element : list) {
+            serialize(printer, element.get());
+        }
+        printer.exit_array(size);
+        printer.exit_property("prefix");
+    }
+    printer.exit_object("ScanStrategy");
+}
+
+void BindingSerializer::serialize(common::util::DataSerializer& printer, ScanStrategy::Kind value) {
+    if (show_enum_kind()) {
+        if (show_qualified_kind()) {
+            printer.enter_object("Kind");
+        } else {
+            printer.enter_object("ScanStrategy::Kind");
+        }
+        printer.enter_property("value");
+        printer.value(to_string_view(value));
+        printer.exit_property("value");
+        if (show_qualified_kind()) {
+            printer.exit_object("Kind");
+        } else {
+            printer.exit_object("ScanStrategy::Kind");
+        }
+    } else {
+        printer.value(to_string_view(value));
+    }
+}
+
+void BindingSerializer::serialize(common::util::DataSerializer& printer, JoinStrategy const* value) {
+    if (value == nullptr) {
+        printer.value(nullptr);
+        return;
+    }
+    printer.enter_object("JoinStrategy");
+    {
+        printer.enter_property("kind");
+        serialize(printer, value->kind());
+        printer.exit_property("kind");
+    }
+    {
+        printer.enter_property("natural");
+        printer.value(value->natural());
+        printer.exit_property("natural");
+    }
+    {
+        printer.enter_property("left_outer");
+        printer.value(value->left_outer());
+        printer.exit_property("left_outer");
+    }
+    {
+        printer.enter_property("right_outer");
+        printer.value(value->right_outer());
+        printer.exit_property("right_outer");
+    }
+    {
+        printer.enter_property("left_semi");
+        printer.value(value->left_semi());
+        printer.exit_property("left_semi");
+    }
+    {
+        printer.enter_property("right_semi");
+        printer.value(value->right_semi());
+        printer.exit_property("right_semi");
+    }
+    {
+        printer.enter_property("columns");
+        auto& list = value->columns();
+        auto size = list.size();
+        printer.enter_array(size);
+        for (auto& element : list) {
+            serialize(printer, &element);
+        }
+        printer.exit_array(size);
+        printer.exit_property("columns");
+    }
+    printer.exit_object("JoinStrategy");
+}
+
+void BindingSerializer::serialize(common::util::DataSerializer& printer, JoinStrategy::Kind value) {
+    if (show_enum_kind()) {
+        if (show_qualified_kind()) {
+            printer.enter_object("Kind");
+        } else {
+            printer.enter_object("JoinStrategy::Kind");
+        }
+        printer.enter_property("value");
+        printer.value(to_string_view(value));
+        printer.exit_property("value");
+        if (show_qualified_kind()) {
+            printer.exit_object("Kind");
+        } else {
+            printer.exit_object("JoinStrategy::Kind");
+        }
+    } else {
+        printer.value(to_string_view(value));
+    }
+}
+
+void BindingSerializer::serialize(common::util::DataSerializer& printer, JoinStrategy::Column const* value) {
     if (value == nullptr) {
         printer.value(nullptr);
         return;
     }
     if (show_qualified_kind()) {
-        printer.enter_object("JoinColumn");
+        printer.enter_object("Column");
     } else {
-        printer.enter_object("RelationBinding::JoinColumn");
+        printer.enter_object("JoinStrategy::Column");
     }
     {
         printer.enter_property("qualifiers");
@@ -393,43 +588,10 @@ void BindingSerializer::serialize(common::util::DataSerializer& printer, Relatio
         printer.exit_property("nullify_right_source");
     }
     if (show_qualified_kind()) {
-        printer.exit_object("JoinColumn");
+        printer.exit_object("Column");
     } else {
-        printer.exit_object("RelationBinding::JoinColumn");
+        printer.exit_object("JoinStrategy::Column");
     }
-}
-
-void BindingSerializer::serialize(common::util::DataSerializer& printer, common::schema::TableInfo const* value) {
-    if (!is_valid(value)) {
-        printer.value(nullptr);
-        return;
-    }
-    printer.enter_object("TableInfo");
-    {
-        printer.enter_property("name");
-        printer.value(value->name());
-        printer.exit_property("name");
-    }
-    printer.exit_object("TableInfo");
-}
-
-void BindingSerializer::serialize(common::util::DataSerializer& printer, common::schema::IndexInfo const* value) {
-    if (!is_valid(value)) {
-        printer.value(nullptr);
-        return;
-    }
-    printer.enter_object("IndexInfo");
-    {
-        printer.enter_property("is_primary");
-        printer.value(value->is_primary());
-        printer.exit_property("is_primary");
-    }
-    {
-        printer.enter_property("name");
-        printer.value(value->name());
-        printer.exit_property("name");
-    }
-    printer.exit_object("IndexInfo");
 }
 
 }  // namespace shakujo::analyzer::binding

--- a/analyzer/src/impl/Engine.h
+++ b/analyzer/src/impl/Engine.h
@@ -236,7 +236,7 @@ private:
 
     std::vector<std::shared_ptr<binding::VariableBinding>> create_column_variables(common::schema::TableInfo const&);
 
-    std::vector<binding::RelationBinding::JoinColumn> compute_join_columns(
+    std::vector<binding::JoinStrategy::Column> compute_join_columns(
             model::expression::relation::JoinExpression const* node,
             std::vector<std::shared_ptr<binding::VariableBinding>> const& left_variables,
             std::vector<std::shared_ptr<binding::VariableBinding>> const& right_variables,

--- a/analyzer/test/SyntaxValidatorRelationTest.cpp
+++ b/analyzer/test/SyntaxValidatorRelationTest.cpp
@@ -97,6 +97,12 @@ TEST_F(SyntaxValidatorRelationTest, JoinExpression) {
         literal(),
         literal()
     ));
+    validate(f.JoinExpression(
+        Kind::LEFT_OUTER,
+        literal(),
+        literal(),
+        literal()
+    ));
     should_error(f.JoinExpression(
         Kind::INNER,
         {},
@@ -114,6 +120,12 @@ TEST_F(SyntaxValidatorRelationTest, JoinExpression) {
         literal(),
         literal(),
         literal()
+    ));
+    should_error(f.JoinExpression(
+        Kind::LEFT_OUTER,
+        literal(),
+        literal(),
+        {}
     ));
 }
 


### PR DESCRIPTION
This PR introduces `{Scan,Join}Strategy` into `RelationBinding`. They are only available on `{Scan,Join}Expression` and represent how they execute.

The following methods are moved in this PR:
* `RelationBinding::join_columns()` -> `JoinStrategy::columns()`
* `RelationBinding::Profile::source_index()` -> `ScanStrategy::index()`